### PR TITLE
Fixed formatting for NPM website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ gulp-json-transform [![Build Status](https://travis-ci.org/thaggie/gulp-json-tra
 A [gulp](https://github.com/gulpjs/gulp) plugin to transform JSON files, pipe JSON files through it and transform them to other JSON files or other text based formats.
 
 
-##Usage
+## Usage
 
 
 First install `gulp-json-transform` as a development dependency:


### PR DESCRIPTION
The [NPM page](https://www.npmjs.com/package/gulp-json-transform) for this package renders a literal `##Usage` instead of using a header format if there is no space after the `##`.
