### PR TITLE
More Helpful Error Message

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function jsonPromiseParse(rawStr) {
     try {
       json = JSON.parse(rawStr);
     } catch (e) {
-      return reject(new Error('Invalid JSON'));
+      return reject(new Error('Invalid JSON: ' + e.message));
     }
     resolve(json);
   });


### PR DESCRIPTION
Was wondering if we could print a more helpful error message when Syntax Errors are thrown by parse?
